### PR TITLE
refactor to support only 2.10.6+, 2.11.8+ and 2.12.x

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.11
+sbt.version=0.13.13
+

--- a/src/main/scala/PartialUnification.scala
+++ b/src/main/scala/PartialUnification.scala
@@ -23,6 +23,7 @@ object PartialUnification extends AutoPlugin {
       case (2, 11, 8) => pluginDependency
       case (2, 11, p) if p >= 9 => flag
       case (2, 12, _) => flag
+      case (2, 13, _) => flag
       case _ => sys.error(s"scala version $scalaVersion is not supported by this plugin.")
     }
   }


### PR DESCRIPTION
Thanks for your nice work. I'd like to recommend this plugin to typelevel/cats users once we get rid of the `Unapply` machinery per this [issue](https://github.com/typelevel/cats/issues/1073#issuecomment-225381900)

I made some changes here
1. support 2.11.9+ with the scalacOption
2. stop supporting versions prior to 2.10.6 and after 2.13, for 2.10.6- there is no plugin available. For 2.14+ it's too far ahead we don't know if the flag is still supported, by that time this plugin is probably obsolete. 
3. Fail when the scala version falls out of the supported range which is 2.10.6 - 2.13.x



