### PR TITLE
Add support for Dotty

### DIFF
--- a/src/main/scala/PartialUnification.scala
+++ b/src/main/scala/PartialUnification.scala
@@ -24,8 +24,7 @@ object PartialUnification extends AutoPlugin {
       case (2, 11, p, _) if p >= 9 => flag
       case (2, 12, _, _) => flag
       case (2, 13, _, milestone +: _) if milestone == "M1" || milestone == "M2" || milestone == "M3" => flag    // ignoring the M4 snapshot
-      case (2, 13, _, _) => Resolution.NothingHappens
-      case _ => sys.error(s"scala version $scalaVersion is not supported by this plugin.")
+      case _ => Resolution.NothingHappens
     }
   }
 


### PR DESCRIPTION
This just changes the default case to do nothing instead of failing with
an error, since Dotty supports partial unification by default and no one
uses 2.9 or earlier anymore.